### PR TITLE
Fix vmw-cli docker run command

### DIFF
--- a/Linux.md
+++ b/Linux.md
@@ -59,7 +59,7 @@ export VMWARE_CUSTOMER_CONNECT_PASSWORD=<your password>
 
 cd ~/downloads
 
-docker run -itd --name vmw -e VMWUSER='$VMWARE_CUSTOMER_CONNECT_USER' -e VMWPASS='$VMWARE_CUSTOMER_CONNECT_PASSWORD' -v ${PWD}:/files --entrypoint=sh apnex/vmw-cli
+docker run -itd --name vmw -e VMWUSER=$VMWARE_CUSTOMER_CONNECT_USER -e VMWPASS=$VMWARE_CUSTOMER_CONNECT_PASSWORD -v ${PWD}:/files --entrypoint=sh apnex/vmw-cli
 
 # view current files
 docker exec -t vmw vmw-cli ls vmware_tanzu_kubernetes_grid


### PR DESCRIPTION
Using the env vars with the single quotes faille for me in both Mac and Ubuntu (18.04). Removing them worked in both cases